### PR TITLE
Run tests whenever we push (except to trunk)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 on:
-    pull_request:
-        types: [opened, reopened]
+    push:
+        branches-ignore:
+            - 'trunk'
 
 jobs:
     tests:


### PR DESCRIPTION
Because currently the tests aren't getting rerun when you push more commits to an existing PR.